### PR TITLE
Fix on-hover-effect not showing

### DIFF
--- a/src/Widgets/CanvasItem.vala
+++ b/src/Widgets/CanvasItem.vala
@@ -167,13 +167,13 @@ public class GtkCanvas.CanvasItem : Clutter.Actor {
         hover_action = new HoverAction (this);
 
         enter_event.connect (() => {
-            if (on_hover_effect) {
+            if (this.on_hover_effect) {
                 hover_action.toggle (true);
             }
         });
 
         leave_event.connect (() => {
-            if (on_hover_effect) {
+            if (this.on_hover_effect) {
                 hover_action.toggle (false);
             }
         });


### PR DESCRIPTION
The lambda function used in the connect was keeping the old value instead of grabbing it from `this`. thus it was always taking `false` no matter what