### PR TITLE
fix argv in demo

### DIFF
--- a/demo/Window.vala
+++ b/demo/Window.vala
@@ -19,7 +19,7 @@
 * Authored by: Felipe Escoto <felescoto95@hotmail.com>
 */
 
-int main (string argv[]) {
+int main (string[] argv) {
     GtkClutter.init (ref argv);
 
     var window = new Gtk.Window ();


### PR DESCRIPTION
It didn't compile with the original version on Fedora 30.
I'm no Vala expert but this seems to fix it.